### PR TITLE
Add variant grouping view

### DIFF
--- a/lib/export_screen.dart
+++ b/lib/export_screen.dart
@@ -2,13 +2,39 @@ import 'package:flutter/material.dart';
 
 import 'main.dart';
 
-class ExportScreen extends StatelessWidget {
+class ExportScreen extends StatefulWidget {
   const ExportScreen({super.key});
+
+  @override
+  State<ExportScreen> createState() => _ExportScreenState();
+}
+
+class _ExportScreenState extends State<ExportScreen> {
+  bool _byVariant = false;
+  final Map<String, Color> _variantColors = {};
+
+  Color _colorForVariant(String variant) {
+    return _variantColors.putIfAbsent(
+      variant,
+      () => Colors
+          .primaries[_variantColors.length % Colors.primaries.length]
+          .shade100,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text("Today's Orders")),
+      appBar: AppBar(
+        title: const Text("Today's Orders"),
+        actions: [
+          IconButton(
+            icon: Icon(_byVariant ? Icons.table_view : Icons.palette),
+            tooltip: _byVariant ? 'View by product' : 'Group by variant',
+            onPressed: () => setState(() => _byVariant = !_byVariant),
+          ),
+        ],
+      ),
       body: StreamBuilder(
         stream: todaysOrders(),
         builder: (context, snapshot) {
@@ -21,6 +47,7 @@ class ExportScreen extends StatelessWidget {
           }
 
           final Map<String, _Summary> grouped = {};
+          final Map<String, _VariantSummary> variantGrouped = {};
           for (var d in docs) {
             final data = d.data();
             final name = data['foodName'] as String;
@@ -28,6 +55,51 @@ class ExportScreen extends StatelessWidget {
             final price = (data['price'] as num).toDouble();
             final key = '$name||$notes';
             grouped.putIfAbsent(key, () => _Summary(name, notes, price)).count++;
+
+            final v = variantGrouped.putIfAbsent(notes, () => _VariantSummary(notes));
+            v.count++;
+            v.total += price;
+          }
+
+          if (_byVariant) {
+            final rows = variantGrouped.values.map((s) {
+              return DataRow(
+                color: MaterialStateProperty.all(_colorForVariant(s.notes)),
+                cells: [
+                  DataCell(Text(s.notes.isEmpty ? '-' : s.notes)),
+                  DataCell(Text('${s.count}')),
+                  DataCell(Text('€${s.total.toStringAsFixed(2)}')),
+                ],
+              );
+            }).toList();
+
+            final totalSum = variantGrouped.values
+                .fold<double>(0, (p, e) => p + e.total);
+
+            return Column(
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: DataTable(
+                      columns: const [
+                        DataColumn(label: Text('Variant')),
+                        DataColumn(label: Text('Qty')),
+                        DataColumn(label: Text('Total')),
+                      ],
+                      rows: rows,
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Text(
+                    'Grand total: €${totalSum.toStringAsFixed(2)}',
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+              ],
+            );
           }
 
           final rows = grouped.values.map((s) {
@@ -81,4 +153,14 @@ class _Summary {
   int count;
 
   _Summary(this.name, this.notes, this.price) : count = 0;
+}
+
+class _VariantSummary {
+  final String notes;
+  int count;
+  double total;
+
+  _VariantSummary(this.notes)
+      : count = 0,
+        total = 0;
 }


### PR DESCRIPTION
## Summary
- make ExportScreen a StatefulWidget
- add toggle to group orders by variant with color-coded rows

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684958f6f32883239624e327f1b26f73